### PR TITLE
Do not create R/O directories

### DIFF
--- a/kobackupdec.py
+++ b/kobackupdec.py
@@ -560,8 +560,6 @@ def main(password, backup_path_in, dest_path_out):
         unk_files.remove(entry)
 
     all_dest_files = dest_path_out.glob('**/*')
-    for entry in all_dest_files:
-        os.chmod(entry, 0o444)
 
     for entry in apk_files:
         logging.warning('APK file not handled: %s', entry.name)


### PR DESCRIPTION
When using the script on Linux the destination directories will be set to read only resulting in this weird error:

`Traceback (most recent call last):
  File "./kobackupdec.py", line 620, in <module>
    main(user_password, backup_path, dest_path)
  File "./kobackupdec.py", line 564, in main
    os.chmod(entry, 0o444)
PermissionError: [Errno 13] Permission denied: '../Huawei_dec/storage/Documents'
`
The os.chmod is unnecessary/contraproductive