### PR TITLE
fix for none working empty salt check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 #ignore all
 *
-#track dirs
-!*/
-#track #-DLH-# dir
-!/#-DLH-#/
 #track python files
 !*.py
 #track readme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+#ignore all
+*
+#track dirs
+!*/
+#track #-DLH-# dir
+!/#-DLH-#/
+#track python files
+!*.py
+#track readme
+!readme.md
+#track .gitignore
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# disclaimer
+this is just an updated version of the original script, all credits to the original author
+
+## updates
++ 'audios': 'audio' in `decrypt_files_in_folder()` for decrypting audio files
++ fast workaround for new style backup without `checkMSG` in `info.xml`
+
 # kobackupdec
 Huawei backup decryptor
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# disclaimer
-this is just an updated version of the original script, all credits to the original author
-
 # kobackupdec
 Huawei backup decryptor
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# disclaimer
+this is just an updated version of the original script, all credits to the original author
+
 # kobackupdec
 Huawei backup decryptor
 

--- a/kobackupdec.py
+++ b/kobackupdec.py
@@ -711,7 +711,7 @@ def decrypt_files_in_root(decrypt_info, path_in, path_out):
 
 def decrypt_files_in_folder(decrypt_info, folder, path_out):
 
-    folder_to_media_type = {'movies': 'video', 'pictures': 'photo'}
+    folder_to_media_type = {'movies': 'video', 'pictures': 'photo', 'audios': 'audio', }
 
     media_out_dir = path_out.absolute().joinpath('storage')
     media_unk_dir = path_out.absolute().joinpath('unknown')

--- a/kobackupdec.py
+++ b/kobackupdec.py
@@ -266,8 +266,11 @@ class Decryptor:
         self._bkey_sha256 = SHA256.new(self._bkey).digest()[:16]
         logging.debug('SHA256(BKEY)[%s] = %s', len(self._bkey_sha256),
                       binascii.hexlify(self._bkey_sha256))
+        try:
+            salt = self._checkMsg[32:]
+        except:
+            salt = None # or False whatever you want
 
-        salt = self._checkMsg[32:]
         if salt:
             logging.debug('SALT[%s] = %s', len(salt), binascii.hexlify(salt))
 

--- a/kobackupdec.py
+++ b/kobackupdec.py
@@ -266,21 +266,32 @@ class Decryptor:
         logging.debug('SHA256(BKEY)[%s] = %s', len(self._bkey_sha256),
                       binascii.hexlify(self._bkey_sha256))
 
-        salt = self._checkMsg[32:]
-        logging.debug('SALT[%s] = %s', len(salt), binascii.hexlify(salt))
+        try:
+            salt = self._checkMsg[32:]
+            logging.debug('SALT[%s] = %s', len(salt), binascii.hexlify(salt))
 
-        res = PBKDF2(self._bkey, salt, Decryptor.dklen, Decryptor.count,
-                     Decryptor.prf, hmac_hash_module=None)
-        logging.debug('KEY check expected = %s',
-                      binascii.hexlify(self._checkMsg[:32]))
-        logging.debug('RESULT = %s', binascii.hexlify(res))
+            res = PBKDF2(self._bkey, salt, Decryptor.dklen, Decryptor.count,
+                         Decryptor.prf, hmac_hash_module=None)
+            logging.debug('KEY check expected = %s',
+                          binascii.hexlify(self._checkMsg[:32]))
+            logging.debug('RESULT = %s', binascii.hexlify(res))
 
-        if res == self._checkMsg[:32]:
-            logging.info('OK, backup key is correct!')
+            if res == self._checkMsg[:32]:
+                logging.info('OK, backup key is correct!')
+                self._good = True
+            else:
+                logging.error('KO, backup key is wrong!')
+                self._good = False
+
+        except:
+            print()
+            logging.error('NEW TYPE of backup found!')
+            logging.error('no check for correct key! will try to decrypt anyway...')
+            logging.error('be SURE that pass is correct!')
+            print()
+            input('press ENTER to continue...or cancel script with CTRL + C')
             self._good = True
-        else:
-            logging.error('KO, backup key is wrong!')
-            self._good = False
+            pass
 
     def decrypt_package(self, dec_material, data):
         if not self._good:


### PR DESCRIPTION
the check for new style backups has a flaw

actual code in line 270 `salt = self._checkMsg[32:]` results in error

```
Traceback (most recent call last):
File "kobackupdec.py", line 270, in crypto_init
salt = self._checkMsg[32:]
TypeError: 'NoneType' object is not subscriptable
```

because of the "empty" checkMsg in info.xml

plz add my fix to prevent this

```
try:
    salt = self._checkMsg[32:]
except:
    salt = None # or
    salt = False # whatever codestyle you prefer 
```
